### PR TITLE
solved: 백준 15681 트리와 쿼리 - dfs, dp

### DIFF
--- a/boj/solved/dfs/15681/Main.java
+++ b/boj/solved/dfs/15681/Main.java
@@ -1,0 +1,60 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+  static int[] parent;
+  static int[] visited;
+  static int[] children;
+  static List<Integer>[] graph;
+  static int n, r, q;
+
+  static int solve(int cur) {
+
+    visited[cur] = 1;
+
+      for(int next: graph[cur]) {
+        if (visited[next] == 0) {
+            parent[next] = cur;
+            children[cur] += solve(next);
+          }    
+        }
+      return children[cur];
+  }
+
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    StringTokenizer st = new StringTokenizer(br.readLine());
+
+    n = Integer.parseInt(st.nextToken());
+    r = Integer.parseInt(st.nextToken());
+    q = Integer.parseInt(st.nextToken());
+
+    parent = new int[n+1];
+    children = new int[n+1];
+    visited = new int[n+1];
+    Arrays.fill(children, 1);
+    graph = new ArrayList[n+1];
+
+    for (int i = 0; i <= n; i++) {
+      graph[i] = new ArrayList<>();
+    }
+
+    for (int i = 0; i < n-1; i++) {
+      st = new StringTokenizer(br.readLine());
+
+      int from, to;
+      from = Integer.parseInt(st.nextToken());
+      to = Integer.parseInt(st.nextToken());
+      graph[from].add(to);
+      graph[to].add(from);
+    }
+    solve(r);
+    for (int i = 0; i < q; i++) {
+      st = new StringTokenizer(br.readLine());
+      int node = Integer.parseInt(st.nextToken());
+      System.out.println(children[node]);
+    }
+  }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ 
- 문제 번호: 15681
- 문제 링크: https://www.acmicpc.net/problem/15681
- 풀이 시간: 약 30분
- 분류: dfs / 트리

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: DFS
- 사용한 알고리즘/자료구조:
children 배열을 하위노드 갯수 카운팅 용으로 사용했습니다.
dfs로 방문처리하며 누적

## 2) 시간/공간 복잡도

- 시간 복잡도:
- 공간 복잡도:

## 3) 오답에서 무엇을 배웠는가? (있다면)

- W1/W2/W3에서 고친 핵심 포인트:
- 문제의 본질을 이해하게 된 부분:

---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분:
- 더 효율적인 풀이 가능 여부:
- 코드 스타일 / 구조 개선 의견 요청:

---

# 📝 기타

(선택 입력)


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
