### PR TITLE
solved: 백준 14921 용액 합성하기 - 투포인터

### DIFF
--- a/boj/solved/two-pointer/Main.java
+++ b/boj/solved/two-pointer/Main.java
@@ -1,0 +1,57 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+  static int n, l, r, negative_flag;
+  static long[] arr;
+  static long cur_sum, _min;
+
+  public static void main(String[] args) throws IOException{
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st;
+    
+    n = Integer.parseInt(br.readLine());
+    st = new StringTokenizer(br.readLine());
+
+    arr = new long[n];
+
+    for (int i = 0; i < n; i++) {
+      arr[i] = Long.parseLong(st.nextToken());
+    }
+
+    l = 0; r = n - 1;
+    _min = Long.MAX_VALUE;
+  
+    while (l < r) {
+      cur_sum = arr[l] + arr[r];
+
+      if (Math.abs(cur_sum) < _min) {
+        if (cur_sum < 0) {
+          negative_flag = 1;
+        }
+        else {
+          negative_flag = 0;
+        }
+        _min = Math.abs(cur_sum);
+      }
+
+      if (cur_sum > 0) {
+        r--;
+      }
+      else if (cur_sum < 0) {
+        l++;
+      }
+      else {
+        System.out.println(0);
+        return;
+      }
+    }
+
+    if (negative_flag == 1) {
+      _min *= -1;
+    }
+    System.out.println(_min);
+  }
+  
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 14921
- 문제 링크: https://www.acmicpc.net/problem/14921
- 풀이 시간: 약 20분(멘토링 중 풀어서 정확하지 않은 시간입니다.)
- 분류: 투포인터

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: cur_sum이 음수일 때 고려
- 사용한 알고리즘/자료구조: 투포인터

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N)
- 공간 복잡도:

현재 ```arr[l] + arr[r]```은 음수가 나올 수 있고,
정답 판별은 0과 가까운 합이기 때문에 절댓값이 필요하여 고려했어야했습니다.
풀이 내 ```negative_flag``` 사용해서 절댓값이 최소일 때 flag 세웠습니다.
해당 과정에서 코드가 깔끔하지 못했네요.

## 3) 오답에서 무엇을 배웠는가? (있다면)

- W1/W2/W3에서 고친 핵심 포인트:
- 문제의 본질을 이해하게 된 부분:

---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분:
- 더 효율적인 풀이 가능 여부:
- 코드 스타일 / 구조 개선 의견 요청:

---

# 📝 기타

(선택 입력)


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
