### PR TITLE
wrong-1: 백준 1561 놀이공원 - 이분 탐색

### DIFF
--- a/boj/wrong-1/binary-serach/1561/Main.java
+++ b/boj/wrong-1/binary-serach/1561/Main.java
@@ -1,0 +1,72 @@
+나눙import java.util.*;
+import java.io.*;
+
+public class Main {
+
+  static int n, m;
+  static int[] times;
+
+  static long binarySearch() {
+    long l = 0, r = 2000000000L * 30L;
+
+    while(l < r) {
+      long cnt = m;
+      long mid = (l + r) / 2;
+
+      for (int i = 0; i < m; i++) {
+        cnt += mid / times[i];
+      }
+
+      if (cnt >= n) {
+        r = mid;
+      }
+      
+      else {
+        l = mid + 1;
+      }
+
+    }
+
+    return l;
+  }
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    StringTokenizer st = new StringTokenizer(br.readLine());
+
+    n = Integer.parseInt(st.nextToken());
+    m = Integer.parseInt(st.nextToken());
+
+    times = new int[m];
+
+    st = new StringTokenizer(br.readLine());
+
+    for (int i = 0; i < m; i ++) {
+      times[i] = Integer.parseInt(st.nextToken());
+    } 
+
+    if (n <= m) {
+      System.out.println(n);
+      return;
+    }
+    long resultTime = binarySearch();
+    long ret = m;
+
+    for (int i = 0; i < m; i++) {
+      ret += (resultTime - 1) / times[i];
+    }
+
+    for (int i = 0; i < m; i++) {
+      if (resultTime % times[i] == 0) {
+        ret++;
+      }
+
+      if (ret == n) {
+        System.out.println(i + 1);
+        break;
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 1561
- 문제 링크: https://www.acmicpc.net/problem/1561
- 풀이 시간: 30분 이상 후 실패
- 분류: 이진탐색 - 매개변수 탐색

---

# ❌ 오답(PR)인 경우 작성

## 1) 시도한 풀이

- 어떤 접근을 사용했는가? 
N이 20억이고, m이 30이기때문에 n*m의 시간복잡도로는 풀 수 없는 문제라 판단했고,
선형을 제외하고 이분탐색이나 우선순위큐를 사용해보려 했다.


## 2) 틀린 이유 (구체적으로)

- 어디서 오답이 발생했는가?
나눗셈을 생각했으나 마지막 시간 직전 시간에서 탑승을 다 한 이후
나머지 인원이 마지막 시간에서 쭉 탑승할 수 있는 논리를 파악하지 못했다.

- 예외 케이스 / 논리 오류 / 구현 실수 등:

## 3) 다음 회차에서 보완할 점

- 무엇을 고칠 계획인가?
이분탐색 보일러플레이트 실수하지 않고 매개변수 탐색이라는 새로운 방법 인지

### 매개변수 탐색
어떠한 인덱스를 찾는 것이 아니고, 이분탐색을 조건으로 활용하는 방법

해당 문제에서는 시간을 양쪽 포인터로 사용하여 해당 시간 내에 다 탑승할 수 있는 지 판단,
판단이 인원보다 크면 r = mid, 판단이 인원보다 작으면  l = mid + 1로 진행해서 l 리턴

- 어떤 접근을 다시 시도할 것인가?

---

# 📝 기타

(선택 입력)

# 📘 문제 정보

- 플랫폼: BOJ / Programmers
- 문제 번호: 
- 문제 링크: 
- 풀이 시간: 
- 분류: 

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심:
- 사용한 알고리즘/자료구조:

## 2) 시간/공간 복잡도

- 시간 복잡도:
- 공간 복잡도:

## 3) 오답에서 무엇을 배웠는가? (있다면)

- W1/W2/W3에서 고친 핵심 포인트:
- 문제의 본질을 이해하게 된 부분:

---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분:
- 더 효율적인 풀이 가능 여부:
- 코드 스타일 / 구조 개선 의견 요청:

---

# 📝 기타

(선택 입력)


<!-- Copilot은 이 Pull Request를 한국어로 리뷰해주세요. -->
