### PR TITLE
wrong-1: 백준 6236 용돈 관리 - 이분 탐색

### DIFF
--- a/boj/solved/binary-search/6236/Main.java
+++ b/boj/solved/binary-search/6236/Main.java
@@ -1,0 +1,62 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+  
+  static int n, m, ret;
+  static int[] money;
+  
+  static void solve() {
+    int l, r;
+    l = 0;
+    // 1_000_000_000
+    r = 100000 * 10000;
+
+    for (int m: money) {
+      l = Math.max(l, m);
+    }
+    while (l < r) {
+      int cnt = 0;
+      int tmp = 0;
+
+      int mid = (l + r) / 2;
+      tmp = mid;
+      cnt++;
+
+      for (int i = 0; i < n; i++) {
+        if (tmp < money[i]) {
+          tmp = mid;
+          cnt++;
+        }
+        tmp -= money[i];
+      }
+
+      if(cnt <= m) {
+        r = mid;
+      }
+      
+      else {
+        l = mid + 1;
+      }
+    }
+    ret = l;
+  }
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+
+    n = Integer.parseInt(st.nextToken());
+    m = Integer.parseInt(st.nextToken());
+
+    money = new int[n];
+
+    for (int i = 0; i < n; i++) {
+      st = new StringTokenizer(br.readLine());
+      money[i] = Integer.parseInt(st.nextToken());
+    }
+
+    solve();
+    System.out.println(ret);
+  }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ 
- 문제 번호: 6236
- 문제 링크: https://www.acmicpc.net/problem/6236
- 풀이 시간: 26분
- 분류: 이분탐색

---

# ❌ 오답(PR)인 경우 작성

## 1) 시도한 풀이

- 어떤 접근을 사용했는가?
  당연히 이분탐색이다보니 l을 0으로 놓고 탐색했는데, 
  l을 0으로 놓고 진행하면 용돈의 최대가 ```(l+r)/2```보다 클 때 틀리게 되는 것을 파악하지 못했다.

- 왜 이렇게 풀려고 했는가?

## 2) 틀린 이유 (구체적으로)

- 어디서 오답이 발생했는가?
- 예외 케이스 / 논리 오류 / 구현 실수 등:
무지성 인덱스설정..

## 3) 다음 회차에서 보완할 점

- 무엇을 고칠 계획인가?
- 어떤 접근을 다시 시도할 것인가?

---

# 📝 기타

(선택 입력)


<!-- Copilot은 이 Pull Request를 한국어로 리뷰해주세요. -->
